### PR TITLE
global: addition of MARC21 mappings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -39,4 +39,5 @@ recursive-include docs Makefile
 recursive-include examples *.py
 recursive-include invenio_marc21 *.html
 recursive-include invenio_marc21 *.po *.pot *.mo
+recursive-include invenio_marc21 *.json
 recursive-include tests *.py

--- a/examples/app.py
+++ b/examples/app.py
@@ -37,10 +37,20 @@ from __future__ import absolute_import, print_function
 
 from flask import Flask
 from flask_babelex import Babel
+from flask_cli import FlaskCLI
+from invenio_search import InvenioSearch
 
 from invenio_marc21 import InvenioMARC21
 
 # Create Flask application
 app = Flask(__name__)
+app.config.update(
+    ELASTICSEARCH_HOST="localhost:9200",
+    SEARCH_ELASTIC_HOSTS="localhost:9200",
+    SEARCH_ELASTIC_KEYWORD_MAPPING={None: ['_all']},
+)
+
 Babel(app)
+FlaskCLI(app)
+InvenioSearch(app)
 InvenioMARC21(app)

--- a/invenio_marc21/mappings/__init__.py
+++ b/invenio_marc21/mappings/__init__.py
@@ -22,44 +22,4 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-
-notifications:
-  email: false
-
-sudo: false
-
-language: python
-
-cache:
-  - pip
-
-services:
-  - elasticsearch
-
-env:
-  - REQUIREMENTS=lowest
-  - REQUIREMENTS=release
-  - REQUIREMENTS=devel
-
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-
-before_install:
-  - "travis_retry pip install --upgrade pip setuptools py"
-  - "travis_retry pip install twine wheel coveralls requirements-builder"
-  - "requirements-builder --level=min setup.py > .travis-lowest-requirements.txt"
-  - "requirements-builder --level=pypi setup.py > .travis-release-requirements.txt"
-  - "requirements-builder --level=dev --req requirements-devel.txt setup.py > .travis-devel-requirements.txt"
-
-install:
-  - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"
-  - "travis_retry pip install -e .[all]"
-
-script:
-  - "./run-tests.sh"
-
-after_success:
-  - coveralls
+"""Invenio module with nice defaults for MARC21 overlay."""

--- a/invenio_marc21/mappings/marc21.json
+++ b/invenio_marc21/mappings/marc21.json
@@ -1,0 +1,7971 @@
+{
+  "mappings": {
+    "marc21": {
+      "properties": {
+        "hours": {
+          "properties": {
+            "additional_information": {
+              "type": "string"
+            },
+            "hours": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "system_control_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "system_control_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "canceled_invalid_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_added_entry_geographic_name": {
+          "properties": {
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "geographic_name": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "numbering_peculiarities_note": {
+          "properties": {
+            "numbering_peculiarities_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "standard_technical_report_number": {
+          "properties": {
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "canceled_invalid_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "with_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "with_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "non_marc_information_field": {
+          "properties": {
+            "content_of_non_marc_field": {
+              "type": "string"
+            },
+            "source_of_data": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "national_agricultural_library_call_number": {
+          "properties": {
+            "item_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number_r": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "existence_in_nal_collection": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "dewey_decimal_classification_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "edition_number": {
+              "type": "string"
+            },
+            "standard_or_optional_designation": {
+              "type": "string"
+            },
+            "assigning_agency": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            },
+            "type_of_edition": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "source_of_classification_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "reproduction_note": {
+          "properties": {
+            "place_of_reproduction": {
+              "type": "string"
+            },
+            "type_of_reproduction": {
+              "type": "string"
+            },
+            "note_about_reproduction": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "date_of_reproduction": {
+              "type": "string"
+            },
+            "physical_description_of_reproduction": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "series_statement_of_reproduction": {
+              "type": "string"
+            },
+            "agency_responsible_for_reproduction": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "dates_and_or_sequential_designation_of_issues_reproduced": {
+              "type": "string"
+            },
+            "fixed_length_data_elements_of_reproduction": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "former_title": {
+          "properties": {
+            "title_added_entry": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "date_or_sequential_designation": {
+              "type": "string"
+            },
+            "remainder_of_title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "physical_medium": {
+          "properties": {
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "production_rate_ratio": {
+              "type": "string"
+            },
+            "polarity": {
+              "type": "string"
+            },
+            "support": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "material_base_and_configuration": {
+              "type": "string"
+            },
+            "book_format": {
+              "type": "string"
+            },
+            "materials_applied_to_surface": {
+              "type": "string"
+            },
+            "generation": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "technical_specifications_of_medium": {
+              "type": "string"
+            },
+            "location_within_medium": {
+              "type": "string"
+            },
+            "layout": {
+              "type": "string"
+            },
+            "font_size": {
+              "type": "string"
+            },
+            "information_recording_technique": {
+              "type": "string"
+            },
+            "dimensions": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "creator_contributor_characteristics": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "demographic_group_code": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "demographic_group_term": {
+              "type": "string"
+            },
+            "creator_contributor_code": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "creator_contributor_term": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "system_details_access_to_computer_files": {
+          "properties": {
+            "make_and_model_of_machine": {
+              "type": "string"
+            },
+            "operating_system": {
+              "type": "string"
+            },
+            "programming_language": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "international_standard_book_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "terms_of_availability": {
+              "type": "string"
+            },
+            "canceled_invalid_isbn": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "overseas_acquisition_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "overseas_acquisition_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "added_entry_personal_name": {
+          "properties": {
+            "materials_specified": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "personal_name": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "numeration": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "titles_and_other_words_associated_with_a_name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "attribution_qualifier": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "type_of_personal_name_entry_element": {
+              "type": "string"
+            },
+            "dates_associated_with_a_name": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "fuller_form_of_name": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "type_of_added_entry": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "accumulation_and_frequency_of_use_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "frequency_of_use": {
+              "type": "string"
+            },
+            "accumulation": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "collective_uniform_title": {
+          "properties": {
+            "uniform_title": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "uniform_title_printed_or_displayed": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "fixed_length_data_elements": {
+          "type": "string"
+        },
+        "other_distinguishing_characteristics_of_work_or_expression": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "other_distinguishing_characteristic": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "added_entry_uniform_title": {
+          "properties": {
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "type_of_added_entry": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "participant_or_performer_note": {
+          "properties": {
+            "participant_or_performer_note": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "index_term_occupation": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "form": {
+              "type": "string"
+            },
+            "occupation": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "varying_form_of_title": {
+          "properties": {
+            "type_of_title": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "display_text": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "title_proper_short_title": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "note_added_entry_controller": {
+              "type": "string"
+            },
+            "date_or_sequential_designation": {
+              "type": "string"
+            },
+            "remainder_of_title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_statement_added_entry_personal_name": {
+          "properties": {
+            "volume_sequential_designation": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "type_of_personal_name_entry_element": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "pronoun_represents_main_entry": {
+              "type": "string"
+            },
+            "numeration": {
+              "type": "string"
+            },
+            "dates_associated_with_a_name": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "personal_name": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "titles_and_other_words_associated_with_a_name": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "supplement_special_issue_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "binding_information": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "binding_note": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "creation_production_credits_note": {
+          "properties": {
+            "creation_production_credits_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "playing_time": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "playing_time": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "former_publication_frequency": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "dates_of_former_publication_frequency": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "former_publication_frequency": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "added_entry_hierarchical_place_name": {
+          "properties": {
+            "first_order_political_jurisdiction": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "extraterrestrial_area": {
+              "type": "string"
+            },
+            "country_or_larger_entity": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "intermediate_political_jurisdiction": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "city_subsection": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "other_nonjurisdictional_geographic_region_and_feature": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "replacement_record_information": {
+          "properties": {
+            "explanatory_text": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "replacement_bibliographic_record_control_number": {
+              "type": "string"
+            },
+            "replacement_title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "abbreviated_title": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "abbreviated_title": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "title_added_entry": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "supplement_parent_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "terms_governing_use_and_reproduction_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authorization": {
+              "type": "string"
+            },
+            "jurisdiction": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "authorized_users": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "terms_governing_use_and_reproduction": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "preceding_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "type_of_relationship": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "geographic_area_code": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_local_code": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "local_gac_code": {
+              "type": "string"
+            },
+            "geographic_area_code": {
+              "type": "string"
+            },
+            "iso_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_added_entry_personal_name": {
+          "properties": {
+            "materials_specified": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "dates_associated_with_a_name": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "numeration": {
+              "type": "string"
+            },
+            "personal_name": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "volume_sequential_designation": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "titles_and_other_words_associated_with_a_name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "attribution_qualifier": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "type_of_personal_name_entry_element": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "fuller_form_of_name": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "bibliographic_record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "restrictions_on_access_note": {
+          "properties": {
+            "restriction": {
+              "type": "string"
+            },
+            "authorization": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "standardized_terminology_for_access_restriction": {
+              "type": "string"
+            },
+            "jurisdiction": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "terms_governing_access": {
+              "type": "string"
+            },
+            "authorized_users": {
+              "type": "string"
+            },
+            "physical_access_provisions": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "date_and_time_of_latest_transaction": {
+          "type": "string"
+        },
+        "trade_availability_information": {
+          "properties": {
+            "date_made_out_of_print": {
+              "type": "string"
+            },
+            "marc_country_code": {
+              "type": "string"
+            },
+            "iso_country_code": {
+              "type": "string"
+            },
+            "availability_status_code": {
+              "type": "string"
+            },
+            "publisher_s_discount_category": {
+              "type": "string"
+            },
+            "detailed_date_of_publication": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "identification_of_agency": {
+              "type": "string"
+            },
+            "expected_next_availability_date": {
+              "type": "string"
+            },
+            "publishers_compressed_title_identification": {
+              "type": "string"
+            },
+            "source_of_availability_status_code": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "ownership_and_custodial_history": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "privacy": {
+              "type": "string"
+            },
+            "history": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "location_of_originals_duplicates_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "postal_address": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "custodial_role": {
+              "type": "string"
+            },
+            "repository_location_code": {
+              "type": "string"
+            },
+            "custodian": {
+              "type": "string"
+            },
+            "telecommunications_address": {
+              "type": "string"
+            },
+            "country": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "physical_description": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "size_of_unit": {
+              "type": "string"
+            },
+            "dimensions": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "type_of_unit": {
+              "type": "string"
+            },
+            "accompanying_material": {
+              "type": "string"
+            },
+            "other_physical_details": {
+              "type": "string"
+            },
+            "extent": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "copyright_article_fee_code": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "copyright_article_fee_code_nr": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "gpo_item_number": {
+          "properties": {
+            "gpo_item_number": {
+              "type": "string"
+            },
+            "canceled_invalid_gpo_item_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "copy_and_version_identification_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "copy_identification": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "identifying_markings": {
+              "type": "string"
+            },
+            "presentation_format": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "version_identification": {
+              "type": "string"
+            },
+            "number_of_copies": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "study_program_information_note": {
+          "properties": {
+            "public_note": {
+              "type": "string"
+            },
+            "title_point_value": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "reading_level": {
+              "type": "string"
+            },
+            "interest_level": {
+              "type": "string"
+            },
+            "nonpublic_note": {
+              "type": "string"
+            },
+            "program_name": {
+              "type": "string"
+            },
+            "display_text": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "synthesized_classification_number_components": {
+          "properties": {
+            "root_number": {
+              "type": "string"
+            },
+            "facet_designator": {
+              "type": "string"
+            },
+            "number_in_internal_subarrangement_or_add_table_where_instructions_are_found": {
+              "type": "string"
+            },
+            "classification_number_ending_number_of_span": {
+              "type": "string"
+            },
+            "table_sequence_number_for_internal_subarrangement_or_add_table": {
+              "type": "string"
+            },
+            "number_being_analyzed": {
+              "type": "string"
+            },
+            "digits_added_from_classification_number_in_schedule_or_external_table": {
+              "type": "string"
+            },
+            "digits_added_from_internal_subarrangement_or_add_table": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "table_identification": {
+              "type": "string"
+            },
+            "base_number": {
+              "type": "string"
+            },
+            "table_identification_internal_subarrangement_or_add_table": {
+              "type": "string"
+            },
+            "number_where_instructions_are_found_single_number_or_beginning_number_of_span": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "information_about_documentation_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "information_about_documentation_note": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "fingerprint_identifier": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "unparsed_fingerprint": {
+              "type": "string"
+            },
+            "first_and_second_groups_of_characters": {
+              "type": "string"
+            },
+            "date": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "number_of_volume_or_part": {
+              "type": "string"
+            },
+            "third_and_fourth_groups_of_characters": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "translation_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "bibliography_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "number_of_references": {
+              "type": "string"
+            },
+            "bibliography_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "original_study_number_for_computer_data_files": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "original_study_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "source_agency_assigning_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "dates_of_publication_and_or_sequential_designation": {
+          "properties": {
+            "dates_of_publication_and_or_sequential_designation": {
+              "type": "string"
+            },
+            "format_of_date": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "publication_distribution_imprint": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "name_of_publisher_distributor": {
+              "type": "string"
+            },
+            "date_of_manufacture": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "date_of_publication_distribution": {
+              "type": "string"
+            },
+            "place_of_manufacture": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "sequence_of_publishing_statements": {
+              "type": "string"
+            },
+            "place_of_publication_distribution": {
+              "type": "string"
+            },
+            "manufacturer": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "preferred_citation_of_described_materials_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "preferred_citation_of_described_materials_note": {
+              "type": "string"
+            },
+            "source_of_schema_used": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "funding_information_note": {
+          "properties": {
+            "project_number": {
+              "type": "string"
+            },
+            "contract_number": {
+              "type": "string"
+            },
+            "text_of_note": {
+              "type": "string"
+            },
+            "program_element_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "work_unit_number": {
+              "type": "string"
+            },
+            "undifferentiated_number": {
+              "type": "string"
+            },
+            "grant_number": {
+              "type": "string"
+            },
+            "task_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "additional_physical_form_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "constituent_unit_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "current_publication_frequency": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "current_publication_frequency": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "date_of_current_publication_frequency": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "national_library_of_medicine_copy_statement": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "copy_information": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "dissertation_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "dissertation_note": {
+              "type": "string"
+            },
+            "year_degree_granted": {
+              "type": "string"
+            },
+            "name_of_granting_institution": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "degree_type": {
+              "type": "string"
+            },
+            "dissertation_identifier": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "added_entry_taxonomic_identification": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "non_public_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_taxonomic_identification": {
+              "type": "string"
+            },
+            "public_note": {
+              "type": "string"
+            },
+            "taxonomic_category": {
+              "type": "string"
+            },
+            "common_or_alternative_name": {
+              "type": "string"
+            },
+            "taxonomic_name": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "special_coded_dates": {
+          "properties": {
+            "type_of_date_code": {
+              "type": "string"
+            },
+            "beginning_of_date_valid": {
+              "type": "string"
+            },
+            "source_of_date": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "end_of_date_valid": {
+              "type": "string"
+            },
+            "date_1_ce_date": {
+              "type": "string"
+            },
+            "ending_date_for_aggregated_content": {
+              "type": "string"
+            },
+            "beginning_or_single_date_created": {
+              "type": "string"
+            },
+            "single_or_starting_date_for_aggregated_content": {
+              "type": "string"
+            },
+            "date_resource_modified": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "ending_date_created": {
+              "type": "string"
+            },
+            "date_2_bc_date": {
+              "type": "string"
+            },
+            "date_2_ce_date": {
+              "type": "string"
+            },
+            "date_1_bc_date": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "index_term_uncontrolled": {
+          "properties": {
+            "level_of_index_term": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "type_of_term_or_name": {
+              "type": "string"
+            },
+            "uncontrolled_term": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "medium_of_performance": {
+          "properties": {
+            "alternative_medium_of_performance": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "total_number_of_performers": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "soloist": {
+              "type": "string"
+            },
+            "medium_of_performance": {
+              "type": "string"
+            },
+            "access_control": {
+              "type": "string"
+            },
+            "number_of_performers_of_the_same_medium": {
+              "type": "string"
+            },
+            "doubling_instrument": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "imprint_statement_for_films_pre_aacr_1_revised": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "place_of_production_release": {
+              "type": "string"
+            },
+            "producing_company": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "contractual_producer": {
+              "type": "string"
+            },
+            "date_of_production_release": {
+              "type": "string"
+            },
+            "releasing_company": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "digital_graphic_representation": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "column_count": {
+              "type": "string"
+            },
+            "object_count": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "indirect_reference_description": {
+              "type": "string"
+            },
+            "format_of_the_digital_image": {
+              "type": "string"
+            },
+            "row_count": {
+              "type": "string"
+            },
+            "vertical_count": {
+              "type": "string"
+            },
+            "object_type": {
+              "type": "string"
+            },
+            "vpf_topology_level": {
+              "type": "string"
+            },
+            "direct_reference_method": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "number_of_musical_instruments_or_voices_code": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_code": {
+              "type": "string"
+            },
+            "performer_or_ensemble": {
+              "type": "string"
+            },
+            "soloist": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "added_entry_geographic_name": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "geographic_name": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "geospatial_reference_data": {
+          "properties": {
+            "geospatial_reference_method": {
+              "type": "string"
+            },
+            "ellipsoid_name": {
+              "type": "string"
+            },
+            "oblique_line_longitude": {
+              "type": "string"
+            },
+            "reference_method_used": {
+              "type": "string"
+            },
+            "landsat_number_and_path_number": {
+              "type": "string"
+            },
+            "local_planar_or_local_georeference_information": {
+              "type": "string"
+            },
+            "semi_major_axis": {
+              "type": "string"
+            },
+            "coordinate_units_or_distance_units": {
+              "type": "string"
+            },
+            "latitude_resolution": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "false_easting": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "geospatial_reference_dimension": {
+              "type": "string"
+            },
+            "vertical_encoding_method": {
+              "type": "string"
+            },
+            "height_of_perspective_point_above_surface": {
+              "type": "string"
+            },
+            "zone_identifier": {
+              "type": "string"
+            },
+            "local_planar_local_or_other_projection_or_grid_description": {
+              "type": "string"
+            },
+            "longitude_of_central_meridian_or_projection_center": {
+              "type": "string"
+            },
+            "false_northing": {
+              "type": "string"
+            },
+            "azimuthal_angle": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "azimuth_measure_point_longitude_or_straight_vertical_longitude_from_pole": {
+              "type": "string"
+            },
+            "longitude_resolution": {
+              "type": "string"
+            },
+            "vertical_resolution": {
+              "type": "string"
+            },
+            "standard_parallel_or_oblique_line_latitude": {
+              "type": "string"
+            },
+            "denominator_of_flattening_ratio": {
+              "type": "string"
+            },
+            "latitude_of_projection_center_or_projection_origin": {
+              "type": "string"
+            },
+            "scale_factor": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_added_entry_faceted_topical_terms": {
+          "properties": {
+            "focus_term": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "level_of_subject": {
+              "type": "string"
+            },
+            "facet_hierarchy_designation": {
+              "type": "string"
+            },
+            "non_focus_term": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "character_sets_present": {
+          "properties": {
+            "alternate_g0_or_g1_character_set": {
+              "type": "string"
+            },
+            "primary_g1_character_set": {
+              "type": "string"
+            },
+            "primary_g0_character_set": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "form_of_musical_composition_code": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_of_musical_composition_code": {
+              "type": "string"
+            },
+            "source_of_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "publications_about_described_materials_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "publications_about_described_materials_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "cataloging_source": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "original_cataloging_agency": {
+              "type": "string"
+            },
+            "language_of_cataloging": {
+              "type": "string"
+            },
+            "transcribing_agency": {
+              "type": "string"
+            },
+            "modifying_agency": {
+              "type": "string"
+            },
+            "description_conventions": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "former_title_complexity_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "former_title_complexity_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "key_title": {
+          "properties": {
+            "qualifying_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "key_title": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "data_quality_note": {
+          "properties": {
+            "horizontal_position_accuracy_report": {
+              "type": "string"
+            },
+            "attribute_accuracy_report": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "vertical_positional_accuracy_explanation": {
+              "type": "string"
+            },
+            "completeness_report": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "horizontal_position_accuracy_value": {
+              "type": "string"
+            },
+            "display_note": {
+              "type": "string"
+            },
+            "attribute_accuracy_value": {
+              "type": "string"
+            },
+            "logical_consistency_report": {
+              "type": "string"
+            },
+            "cloud_cover": {
+              "type": "string"
+            },
+            "vertical_positional_accuracy_value": {
+              "type": "string"
+            },
+            "horizontal_position_accuracy_explanation": {
+              "type": "string"
+            },
+            "attribute_accuracy_explanation": {
+              "type": "string"
+            },
+            "vertical_positional_accuracy_report": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "added_entry_uncontrolled_related_analytical_title": {
+          "properties": {
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "type_of_added_entry": {
+              "type": "string"
+            },
+            "uncontrolled_related_analytical_title": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "report_number": {
+          "properties": {
+            "report_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "canceled_invalid_report_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "other_relationship_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "cartographic_mathematical_data": {
+          "properties": {
+            "statement_of_zone": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "statement_of_scale": {
+              "type": "string"
+            },
+            "statement_of_equinox": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "statement_of_projection": {
+              "type": "string"
+            },
+            "statement_of_coordinates": {
+              "type": "string"
+            },
+            "outer_g_ring_coordinate_pairs": {
+              "type": "string"
+            },
+            "exclusion_g_ring_coordinate_pairs": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "associated_language": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "language_code": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "language_term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "library_of_congress_copy_issue_offprint_statement": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "copy_information": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_added_entry_uniform_title": {
+          "properties": {
+            "relator_term": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "general_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "general_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "target_audience_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "target_audience_note": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "additional_dewey_decimal_classification_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "table_identification": {
+              "type": "string"
+            },
+            "standard_or_optional_designation": {
+              "type": "string"
+            },
+            "classification_number_ending_number_of_span": {
+              "type": "string"
+            },
+            "assigning_agency": {
+              "type": "string"
+            },
+            "edition_number": {
+              "type": "string"
+            },
+            "type_of_edition": {
+              "type": "string"
+            },
+            "table_sequence_number_for_internal_subarrangement_or_add_table": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "date_time_and_place_of_an_event": {
+          "properties": {
+            "place_of_event": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "type_of_event": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "formatted_date_time": {
+              "type": "string"
+            },
+            "type_of_date_in_subfield_a": {
+              "type": "string"
+            },
+            "geographic_classification_subarea_code": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "geographic_classification_area_code": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "carrier_type": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "carrier_type_term": {
+              "type": "string"
+            },
+            "carrier_type_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "language_note": {
+          "properties": {
+            "language_note": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "information_code_or_alphabet": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "uniform_title": {
+          "properties": {
+            "uniform_title": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "uniform_title_printed_or_displayed": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "library_of_congress_control_number": {
+          "properties": {
+            "lc_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "nucmc_control_number": {
+              "type": "string"
+            },
+            "canceled_invalid_lc_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content_type": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "content_type_code": {
+              "type": "string"
+            },
+            "content_type_term": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "holding_institution": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "holding_institution": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "main_entry_personal_name": {
+          "properties": {
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "titles_and_words_associated_with_a_name": {
+              "type": "string"
+            },
+            "attribution_qualifier": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "type_of_personal_name_entry_element": {
+              "type": "string"
+            },
+            "dates_associated_with_a_name": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "personal_name": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "fuller_form_of_name": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "numeration": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_category_code": {
+          "properties": {
+            "subject_category_code_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "subject_category_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "issuing_body_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "issuing_body_note": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "national_library_of_medicine_call_number": {
+          "properties": {
+            "source_of_call_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "existence_in_nlm_collection": {
+              "type": "string"
+            },
+            "classification_number_r": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type_of_report_and_period_covered_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "type_of_report": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "period_covered": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_statement_added_entry_meeting_name": {
+          "properties": {
+            "volume_sequential_designation": {
+              "type": "string"
+            },
+            "date_of_meeting": {
+              "type": "string"
+            },
+            "meeting_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "pronoun_represents_main_entry": {
+              "type": "string"
+            },
+            "type_of_meeting_name_entry_element": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_meeting_following_jurisdiction_name_entry_element": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "digital_file_characteristics": {
+          "properties": {
+            "encoding_format": {
+              "type": "string"
+            },
+            "transmission_speed": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "resolution": {
+              "type": "string"
+            },
+            "regional_encoding": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "string"
+            },
+            "file_type": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "main_entry_uniform_title": {
+          "properties": {
+            "uniform_title": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "original_version_note": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "location_of_original": {
+              "type": "string"
+            },
+            "key_title_of_original": {
+              "type": "string"
+            },
+            "other_resource_identifier": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "main_entry_of_original": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "series_statement_of_original": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "title_statement_of_original": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "edition_statement_of_original": {
+              "type": "string"
+            },
+            "physical_description_of_original": {
+              "type": "string"
+            },
+            "introductory_phrase": {
+              "type": "string"
+            },
+            "note_about_original": {
+              "type": "string"
+            },
+            "publication_distribution_of_original": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "projection_characteristics_of_moving_image": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "projection_speed": {
+              "type": "string"
+            },
+            "presentation_format": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "scale_note_for_graphic_material": {
+          "properties": {
+            "representative_fraction_of_scale_note": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "remainder_of_scale_note": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "main_entry_meeting_name": {
+          "properties": {
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "date_of_meeting": {
+              "type": "string"
+            },
+            "meeting_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "type_of_meeting_name_entry_element": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_meeting_following_jurisdiction_name_entry_element": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "key": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            },
+            "key_type": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "location_of_other_archival_materials_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "provenance": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "custodian": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "country": {
+              "type": "string"
+            },
+            "relationship": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "host_item_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "abbreviated_title": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "enumeration_and_first_page": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "location": {
+          "properties": {
+            "public_note": {
+              "type": "string"
+            },
+            "shelving_form_of_title": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "classification_part": {
+              "type": "string"
+            },
+            "shelving_order": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "coded_location_qualifier": {
+              "type": "string"
+            },
+            "country_code": {
+              "type": "string"
+            },
+            "piece_physical_condition": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "call_number_suffix": {
+              "type": "string"
+            },
+            "nonpublic_note": {
+              "type": "string"
+            },
+            "shelving_control_number": {
+              "type": "string"
+            },
+            "sublocation_or_collection": {
+              "type": "string"
+            },
+            "copyright_article_fee_code": {
+              "type": "string"
+            },
+            "former_shelving_location": {
+              "type": "string"
+            },
+            "shelving_location": {
+              "type": "string"
+            },
+            "shelving_scheme": {
+              "type": "string"
+            },
+            "item_part": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "source_of_classification_or_shelving_scheme": {
+              "type": "string"
+            },
+            "call_number_prefix": {
+              "type": "string"
+            },
+            "sequence_number": {
+              "type": "string"
+            },
+            "non_coded_location_qualifier": {
+              "type": "string"
+            },
+            "piece_designation": {
+              "type": "string"
+            },
+            "copy_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "citation_references_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "location_within_source": {
+              "type": "string"
+            },
+            "coverage_location_in_source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "coverage_of_source": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "name_of_source": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "national_bibliographic_agency_control_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "national_bibliographic_agency": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "canceled_invalid_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "fixed_length_data_elements_additional_material_characteristics": {
+          "type": "string"
+        },
+        "geographic_classification": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "geographic_classification_subarea_code": {
+              "type": "string"
+            },
+            "code_source": {
+              "type": "string"
+            },
+            "geographic_classification_area_code": {
+              "type": "string"
+            },
+            "populated_place_name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "action_note": {
+          "properties": {
+            "public_note": {
+              "type": "string"
+            },
+            "method_of_action": {
+              "type": "string"
+            },
+            "privacy": {
+              "type": "string"
+            },
+            "contingency_for_action": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "nonpublic_note": {
+              "type": "string"
+            },
+            "extent": {
+              "type": "string"
+            },
+            "action_identification": {
+              "type": "string"
+            },
+            "authorization": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "jurisdiction": {
+              "type": "string"
+            },
+            "site_of_action": {
+              "type": "string"
+            },
+            "time_date_of_action": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "action_agent": {
+              "type": "string"
+            },
+            "action_interval": {
+              "type": "string"
+            },
+            "type_of_unit": {
+              "type": "string"
+            },
+            "action": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "media_type": {
+          "properties": {
+            "media_type_term": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "media_type_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_added_entry_personal_name": {
+          "properties": {
+            "materials_specified": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "fuller_form_of_name": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "numeration": {
+              "type": "string"
+            },
+            "personal_name": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "titles_and_other_words_associated_with_a_name": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "attribution_qualifier": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "type_of_personal_name_entry_element": {
+              "type": "string"
+            },
+            "dates_associated_with_a_name": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "national_bibliography_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "canceled_invalid_national_bibliography_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "national_bibliography_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "government_document_classification_number": {
+          "properties": {
+            "canceled_invalid_classification_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "number_source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "index_term_genre_form": {
+          "properties": {
+            "genre_form_data_or_focus_term": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "facet_hierarchy_designation": {
+              "type": "string"
+            },
+            "non_focus_term": {
+              "type": "string"
+            },
+            "type_of_heading": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "international_standard_serial_number": {
+          "properties": {
+            "incorrect_issn": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "level_of_international_interest": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "canceled_issn_l": {
+              "type": "string"
+            },
+            "issn_l": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "canceled_issn": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "philatelic_issue_data": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "issuing_jurisdiction": {
+              "type": "string"
+            },
+            "denomination": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "trade_price": {
+          "properties": {
+            "currency_code": {
+              "type": "string"
+            },
+            "identification_of_pricing_entity": {
+              "type": "string"
+            },
+            "marc_country_code": {
+              "type": "string"
+            },
+            "price_type_code": {
+              "type": "string"
+            },
+            "price_amount": {
+              "type": "string"
+            },
+            "iso_country_code": {
+              "type": "string"
+            },
+            "unit_of_pricing": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "price_note": {
+              "type": "string"
+            },
+            "tax_rate_1": {
+              "type": "string"
+            },
+            "price_effective_from": {
+              "type": "string"
+            },
+            "tax_rate_2": {
+              "type": "string"
+            },
+            "source_of_price_type_code": {
+              "type": "string"
+            },
+            "price_effective_until": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_statement_added_entry_title": {
+          "properties": {
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "volume_sequential_designation": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "bibliographic_record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "other_edition_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "country_code": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "language_code": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "edition_statement": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "edition_statement": {
+              "type": "string"
+            },
+            "remainder_of_edition_statement": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "language_code": {
+          "properties": {
+            "source_of_code": {
+              "type": "string"
+            },
+            "language_code_of_table_of_contents": {
+              "type": "string"
+            },
+            "language_code_of_subtitles_or_captions": {
+              "type": "string"
+            },
+            "language_code_of_text_sound_track_or_separate_title": {
+              "type": "string"
+            },
+            "language_code_of_original_accompanying_materials_other_than_librettos": {
+              "type": "string"
+            },
+            "language_code_of_original": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "language_code_of_summary_or_abstract": {
+              "type": "string"
+            },
+            "translation_indication": {
+              "type": "string"
+            },
+            "language_code_of_librettos": {
+              "type": "string"
+            },
+            "language_code_of_accompanying_material_other_than_librettos": {
+              "type": "string"
+            },
+            "language_code_of_sung_or_spoken_text": {
+              "type": "string"
+            },
+            "language_code_of_intermediate_translations": {
+              "type": "string"
+            },
+            "language_code_of_original_libretto": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "musical_presentation_statement": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "musical_presentation_statement": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "geographic_coverage_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "geographic_coverage_note": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "time_period_of_content": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "formatted_9999_bc_through_ce_time_period": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "formatted_pre_9999_bc_time_period": {
+              "type": "string"
+            },
+            "time_period_code": {
+              "type": "string"
+            },
+            "type_of_time_period_in_subfield_b_or_c": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "translation_of_title_by_cataloging_agency": {
+          "properties": {
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "statement_of_responsibility": {
+              "type": "string"
+            },
+            "title_added_entry": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "remainder_of_title": {
+              "type": "string"
+            },
+            "language_code_of_translated_title": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "sound_characteristics": {
+          "properties": {
+            "recording_medium": {
+              "type": "string"
+            },
+            "tape_configuration": {
+              "type": "string"
+            },
+            "track_configuration": {
+              "type": "string"
+            },
+            "playing_speed": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "configuration_of_playback_channels": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "type_of_recording": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "groove_characteristic": {
+              "type": "string"
+            },
+            "special_playback_characteristics": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "production_publication_distribution_manufacture_and_copyright_notice": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_production_publication_distribution_manufacture_or_copyright_notice": {
+              "type": "string"
+            },
+            "function_of_entity": {
+              "type": "string"
+            },
+            "name_of_producer_publisher_distributor_manufacturer": {
+              "type": "string"
+            },
+            "sequence_of_statements": {
+              "type": "string"
+            },
+            "place_of_production_publication_distribution_manufacture": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "source_of_acquisition": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_stock_number_acquisition": {
+              "type": "string"
+            },
+            "additional_format_characteristics": {
+              "type": "string"
+            },
+            "stock_number": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "form_of_issue": {
+              "type": "string"
+            },
+            "terms_of_availability": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "organization_and_arrangement_of_materials": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "hierarchical_level": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "organization": {
+              "type": "string"
+            },
+            "arrangement": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "machine_generated_metadata_provenance": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "generation_agency": {
+              "type": "string"
+            },
+            "bibliographic_record_control_number": {
+              "type": "string"
+            },
+            "generation_process": {
+              "type": "string"
+            },
+            "confidence_value": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "method_of_machine_assignment": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "generation_date": {
+              "type": "string"
+            },
+            "validity_end_date": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_added_entry_topical_term": {
+          "properties": {
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "level_of_subject": {
+              "type": "string"
+            },
+            "topical_term_or_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "active_dates": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "location_of_event": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "topical_term_following_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "postal_registration_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "postal_registration_number": {
+              "type": "string"
+            },
+            "source_agency_assigning_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "title_statement": {
+          "properties": {
+            "version": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "inclusive_dates": {
+              "type": "string"
+            },
+            "title_added_entry": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "statement_of_responsibility": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "form": {
+              "type": "string"
+            },
+            "remainder_of_title": {
+              "type": "string"
+            },
+            "bulk_dates": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "classification_numbers_assigned_in_canada": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            },
+            "source_of_call_class_number": {
+              "type": "string"
+            },
+            "type_completeness_source_of_class_call_number": {
+              "type": "string"
+            },
+            "existence_in_lac_collection": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "succeeding_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "type_of_relationship": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "numeric_designation_of_musical_work": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "serial_number": {
+              "type": "string"
+            },
+            "opus_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "publisher_associated_with_opus_number": {
+              "type": "string"
+            },
+            "thematic_index_number": {
+              "type": "string"
+            },
+            "thematic_index_code": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "control_number": {
+          "type": "string"
+        },
+        "date_time_and_place_of_an_event_note": {
+          "properties": {
+            "place_of_event": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "other_event_information": {
+              "type": "string"
+            },
+            "date_of_event": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "date_time_and_place_of_an_event_note": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "methodology_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "methodology_note": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "data_source_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "source_contribution": {
+              "type": "string"
+            },
+            "abbreviated_title": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            },
+            "period_of_content": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "video_characteristics": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "video_format": {
+              "type": "string"
+            },
+            "broadcast_standard": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "planar_coordinate_data": {
+          "properties": {
+            "bearing_reference_meridian": {
+              "type": "string"
+            },
+            "abscissa_resolution": {
+              "type": "string"
+            },
+            "distance_resolution": {
+              "type": "string"
+            },
+            "ordinate_resolution": {
+              "type": "string"
+            },
+            "planar_coordinate_encoding_method": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "bearing_resolution": {
+              "type": "string"
+            },
+            "bearing_units": {
+              "type": "string"
+            },
+            "planar_distance_units": {
+              "type": "string"
+            },
+            "bearing_reference_direction": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "coden_designation": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "coden": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "canceled_invalid_coden": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "coded_cartographic_mathematical_data": {
+          "properties": {
+            "g_ring_longitude": {
+              "type": "string"
+            },
+            "coordinates_easternmost_longitude": {
+              "type": "string"
+            },
+            "beginning_date": {
+              "type": "string"
+            },
+            "coordinates_northernmost_latitude": {
+              "type": "string"
+            },
+            "angular_scale": {
+              "type": "string"
+            },
+            "right_ascension_western_limit": {
+              "type": "string"
+            },
+            "type_of_scale": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "type_of_ring": {
+              "type": "string"
+            },
+            "declination_northern_limit": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "ending_date": {
+              "type": "string"
+            },
+            "coordinates_westernmost_longitude": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "constant_ratio_linear_vertical_scale": {
+              "type": "string"
+            },
+            "name_of_extraterrestrial_body": {
+              "type": "string"
+            },
+            "distance_from_earth": {
+              "type": "string"
+            },
+            "declination_southern_limit": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "right_ascension_eastern_limit": {
+              "type": "string"
+            },
+            "category_of_scale": {
+              "type": "string"
+            },
+            "g_ring_latitude": {
+              "type": "string"
+            },
+            "equinox": {
+              "type": "string"
+            },
+            "coordinates_southernmost_latitude": {
+              "type": "string"
+            },
+            "constant_ratio_linear_horizontal_scale": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "main_entry_corporate_name": {
+          "properties": {
+            "corporate_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number_r": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "date_of_meeting_or_treaty_signing": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "type_of_corporate_name_entry_element": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "immediate_source_of_acquisition_note": {
+          "properties": {
+            "date_of_acquisition": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "accession_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "method_of_acquisition": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "extent": {
+              "type": "string"
+            },
+            "type_of_unit": {
+              "type": "string"
+            },
+            "purchase_price": {
+              "type": "string"
+            },
+            "source_of_acquisition": {
+              "type": "string"
+            },
+            "privacy": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "main_series_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "form_of_work": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "form_of_work": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_added_entry_hierarchical_place_name": {
+          "properties": {
+            "first_order_political_jurisdiction": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "city_subsection": {
+              "type": "string"
+            },
+            "extraterrestrial_area": {
+              "type": "string"
+            },
+            "intermediate_political_jurisdiction": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "other_nonjurisdictional_geographic_region_and_feature": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "country_or_larger_entity": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "record_content_licensor": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "record_content_licensor": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_added_entry_meeting_name": {
+          "properties": {
+            "relator_term": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "name_of_meeting_following_jurisdiction_name_entry_element": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "date_of_meeting": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "meeting_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "type_of_meeting_name_entry_element": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "case_file_characteristics_note": {
+          "properties": {
+            "name_of_variable": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "filing_scheme_or_code": {
+              "type": "string"
+            },
+            "number_of_cases_variables": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "unit_of_analysis": {
+              "type": "string"
+            },
+            "universe_of_data": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_added_entry_meeting_name": {
+          "properties": {
+            "relator_term": {
+              "type": "string"
+            },
+            "name_of_meeting_following_jurisdiction_name_entry_element": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "volume_sequential_designation": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "date_of_meeting": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "meeting_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "type_of_meeting_name_entry_element": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "bibliographic_record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "audience_characteristics": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "demographic_group_code": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "audience_code": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "audience_term": {
+              "type": "string"
+            },
+            "demographic_group_term": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "original_language_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "report_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "publisher_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "publisher_number": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "note_added_entry_controller": {
+              "type": "string"
+            },
+            "type_of_publisher_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_statement_added_entry_corporate_name": {
+          "properties": {
+            "corporate_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "pronoun_represents_main_entry": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "date_of_meeting_or_treaty_signing": {
+              "type": "string"
+            },
+            "volume_sequential_designation": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "type_of_corporate_name_entry_element": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "issued_with_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "series_data_for_related_item": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "security_classification_control": {
+          "properties": {
+            "authorization": {
+              "type": "string"
+            },
+            "declassification_date": {
+              "type": "string"
+            },
+            "downgrading_or_declassification_event": {
+              "type": "string"
+            },
+            "country_of_origin_code": {
+              "type": "string"
+            },
+            "downgrading_date": {
+              "type": "string"
+            },
+            "classification_system": {
+              "type": "string"
+            },
+            "handling_instructions": {
+              "type": "string"
+            },
+            "security_classification": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "external_dissemination_information": {
+              "type": "string"
+            },
+            "controlled_element": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "cumulative_index_finding_aids_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "bibliographic_reference": {
+              "type": "string"
+            },
+            "availability_source": {
+              "type": "string"
+            },
+            "degree_of_control": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "cumulative_index_finding_aids_note": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "universal_decimal_classification_number": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "universal_decimal_classification_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "edition_identifier": {
+              "type": "string"
+            },
+            "type_of_edition": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            },
+            "common_auxiliary_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "computer_file_characteristics": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "computer_file_characteristics": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "control_number_identifier": {
+          "type": "string"
+        },
+        "subject_added_entry_corporate_name": {
+          "properties": {
+            "corporate_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "date_of_meeting_or_treaty_signing": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "type_of_corporate_name_entry_element": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "linking_entry_complexity_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linking_entry_complexity_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "supplement_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "supplement_note": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "added_entry_uncontrolled_name": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "type_of_name": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "electronic_location_and_access": {
+          "properties": {
+            "public_note": {
+              "type": "string"
+            },
+            "electronic_name": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "logon": {
+              "type": "string"
+            },
+            "relationship": {
+              "type": "string"
+            },
+            "bits_per_second": {
+              "type": "string"
+            },
+            "access_method": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "contact_for_access_assistance": {
+              "type": "string"
+            },
+            "nonpublic_note": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            },
+            "processor_of_request": {
+              "type": "string"
+            },
+            "access_number": {
+              "type": "string"
+            },
+            "name_of_location_of_host": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "host_name": {
+              "type": "string"
+            },
+            "terminal_emulation": {
+              "type": "string"
+            },
+            "electronic_format_type": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "link_text": {
+              "type": "string"
+            },
+            "settings": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "operating_system": {
+              "type": "string"
+            },
+            "hours_access_method_available": {
+              "type": "string"
+            },
+            "instruction": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "compression_information": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "national_agricultural_library_copy_statement": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "copy_information": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "added_entry_meeting_name": {
+          "properties": {
+            "relator_term": {
+              "type": "string"
+            },
+            "name_of_meeting_following_jurisdiction_name_entry_element": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "date_of_meeting": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "meeting_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "type_of_meeting_name_entry_element": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "type_of_added_entry": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "projected_publication_date": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "projected_publication_date": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "normalized_date_and_sequential_designation": {
+          "properties": {
+            "public_note": {
+              "type": "string"
+            },
+            "sixth_level_of_enumeration": {
+              "type": "string"
+            },
+            "second_level_of_enumeration": {
+              "type": "string"
+            },
+            "second_level_of_chronology": {
+              "type": "string"
+            },
+            "state_of_issuance": {
+              "type": "string"
+            },
+            "start_end_designator": {
+              "type": "string"
+            },
+            "alternative_numbering_scheme_second_level_of_enumeration": {
+              "type": "string"
+            },
+            "alternative_numbering_scheme_chronology": {
+              "type": "string"
+            },
+            "alternative_numbering_scheme_first_level_of_enumeration": {
+              "type": "string"
+            },
+            "first_level_of_enumeration": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "first_level_of_chronology_issuance": {
+              "type": "string"
+            },
+            "fourth_level_of_chronology": {
+              "type": "string"
+            },
+            "fifth_level_of_enumeration": {
+              "type": "string"
+            },
+            "nonpublic_note": {
+              "type": "string"
+            },
+            "first_level_of_chronology": {
+              "type": "string"
+            },
+            "first_level_textual_designation": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "third_level_of_chronology": {
+              "type": "string"
+            },
+            "third_level_of_enumeration": {
+              "type": "string"
+            },
+            "fourth_level_of_enumeration": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "biographical_or_historical_data": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "biographical_or_historical_data": {
+              "type": "string"
+            },
+            "type_of_data": {
+              "type": "string"
+            },
+            "expansion": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "entity_and_attribute_information_note": {
+          "properties": {
+            "attribute_label": {
+              "type": "string"
+            },
+            "attribute_value_accuracy": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "beginning_and_ending_date_of_attribute_values": {
+              "type": "string"
+            },
+            "entity_type_label": {
+              "type": "string"
+            },
+            "range_domain_minimum_and_maximum": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "display_note": {
+              "type": "string"
+            },
+            "attribute_measurement_frequency": {
+              "type": "string"
+            },
+            "enumerated_domain_value_definition_and_source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "codeset_name_and_source": {
+              "type": "string"
+            },
+            "unrepresentable_domain": {
+              "type": "string"
+            },
+            "attribute_units_of_measurement_and_resolution": {
+              "type": "string"
+            },
+            "entity_type_definition_and_source": {
+              "type": "string"
+            },
+            "enumerated_domain_value": {
+              "type": "string"
+            },
+            "attribute_value_accuracy_explanation": {
+              "type": "string"
+            },
+            "attribute_definition_and_source": {
+              "type": "string"
+            },
+            "entity_and_attribute_detail_citation": {
+              "type": "string"
+            },
+            "entity_and_attribute_overview": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_added_entry_chronological_term": {
+          "properties": {
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "chronological_term": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "type_of_date_or_time_period": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "source_of_description_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_description_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_statement": {
+          "properties": {
+            "series_statement": {
+              "type": "string"
+            },
+            "library_of_congress_call_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "volume_sequential_designation": {
+              "type": "string"
+            },
+            "series_tracing_policy": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "library_of_congress_call_number": {
+          "properties": {
+            "source_of_call_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "existence_in_lc_collection": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "added_entry_corporate_name": {
+          "properties": {
+            "corporate_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "date_of_meeting_or_treaty_signing": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "type_of_added_entry": {
+              "type": "string"
+            },
+            "type_of_corporate_name_entry_element": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "formatted_contents_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "formatted_contents_note": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "level_of_content_designation": {
+              "type": "string"
+            },
+            "statement_of_responsibility": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "country_of_producing_entity": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "country_of_producing_entity": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "summary": {
+          "properties": {
+            "expansion_of_summary_note": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "assigning_source": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "address": {
+          "properties": {
+            "public_note": {
+              "type": "string"
+            },
+            "hours": {
+              "type": "string"
+            },
+            "title_of_contact_person": {
+              "type": "string"
+            },
+            "terms_preceding_attention_name": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "specialized_telephone_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "fax_number": {
+              "type": "string"
+            },
+            "attention_name": {
+              "type": "string"
+            },
+            "country": {
+              "type": "string"
+            },
+            "postal_code": {
+              "type": "string"
+            },
+            "contact_person": {
+              "type": "string"
+            },
+            "telephone_number": {
+              "type": "string"
+            },
+            "level": {
+              "type": "string"
+            },
+            "attention_position": {
+              "type": "string"
+            },
+            "state_or_province": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "tdd_or_tty_number": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "type_of_address": {
+              "type": "string"
+            },
+            "electronic_mail_address": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "additional_physical_form_available_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "availability_source": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "order_number": {
+              "type": "string"
+            },
+            "additional_physical_form_available_note": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "availability_conditions": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "authentication_code": {
+          "properties": {
+            "authentication_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "exhibitions_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "exhibitions_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "awards_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "awards_note": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "imprint_statement_for_sound_recordings_pre_aacr_1": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "place_of_production_release": {
+              "type": "string"
+            },
+            "serial_identification": {
+              "type": "string"
+            },
+            "publisher_or_trade_name": {
+              "type": "string"
+            },
+            "matrix_and_or_take_number": {
+              "type": "string"
+            },
+            "date_of_production_release": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_added_entry_corporate_name": {
+          "properties": {
+            "corporate_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "date_of_meeting_or_treaty_signing": {
+              "type": "string"
+            },
+            "volume_sequential_designation": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "affiliation": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "type_of_corporate_name_entry_element": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "bibliographic_record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "country_of_publishing_producing_entity_code": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "local_subentity_code": {
+              "type": "string"
+            },
+            "marc_country_code": {
+              "type": "string"
+            },
+            "iso_country_code": {
+              "type": "string"
+            },
+            "source_of_local_subentity_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "index_term_function": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "function": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "other_standard_identifier": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "type_of_standard_number_or_code": {
+              "type": "string"
+            },
+            "source_of_number_or_code": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "standard_number_or_code": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "canceled_invalid_standard_number_or_code": {
+              "type": "string"
+            },
+            "terms_of_availability": {
+              "type": "string"
+            },
+            "difference_indicator": {
+              "type": "string"
+            },
+            "additional_codes_following_the_standard_number_or_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type_of_computer_file_or_data_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "type_of_computer_file_or_data_note": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "index_term_curriculum_objective": {
+          "properties": {
+            "main_curriculum_objective": {
+              "type": "string"
+            },
+            "subordinate_curriculum_objective": {
+              "type": "string"
+            },
+            "curriculum_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_term_or_code": {
+              "type": "string"
+            },
+            "correlation_factor": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "system_details_note": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "system_details_note": {
+              "type": "string"
+            },
+            "display_text": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "other_classification_number": {
+          "properties": {
+            "item_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "assigning_agency": {
+              "type": "string"
+            },
+            "number_source": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_added_entry_uniform_title": {
+          "properties": {
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "volume_sequential_designation": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "bibliographic_record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "copyright_or_legal_deposit_number": {
+          "properties": {
+            "display_text": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "copyright_or_legal_deposit_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "assigning_agency": {
+              "type": "string"
+            },
+            "canceled_invalid_copyright_or_legal_deposit_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "date": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "patent_control_information": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "number": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "date": {
+              "type": "string"
+            },
+            "type_of_number": {
+              "type": "string"
+            },
+            "party_to_document": {
+              "type": "string"
+            },
+            "country": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "information_relating_to_copyright_status": {
+          "properties": {
+            "copyright_holder_contact_information": {
+              "type": "string"
+            },
+            "research_date": {
+              "type": "string"
+            },
+            "publication_status": {
+              "type": "string"
+            },
+            "publication_date": {
+              "type": "string"
+            },
+            "privacy": {
+              "type": "string"
+            },
+            "supplying_agency": {
+              "type": "string"
+            },
+            "publisher": {
+              "type": "string"
+            },
+            "copyright_holder": {
+              "type": "string"
+            },
+            "copyright_renewal_date": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "creation_date": {
+              "type": "string"
+            },
+            "copyright_date": {
+              "type": "string"
+            },
+            "copyright_status": {
+              "type": "string"
+            },
+            "personal_creator_death_date": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "country_of_publication_or_creation": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "copyright_statement": {
+              "type": "string"
+            },
+            "corporate_creator": {
+              "type": "string"
+            },
+            "jurisdiction_of_copyright_assessment": {
+              "type": "string"
+            },
+            "personal_creator": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subseries_entry": {
+          "properties": {
+            "material_specific_details": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "edition": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "coden_designation": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "note_controller": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "related_parts": {
+              "type": "string"
+            },
+            "place_publisher_and_date_of_publication": {
+              "type": "string"
+            },
+            "physical_description": {
+              "type": "string"
+            },
+            "main_entry_heading": {
+              "type": "string"
+            },
+            "other_item_identifier": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "originator_dissemination_control": {
+          "properties": {
+            "authorized_recipients_of_material": {
+              "type": "string"
+            },
+            "originator_control_term": {
+              "type": "string"
+            },
+            "other_restrictions": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "originating_agency": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "musical_incipits_information": {
+          "properties": {
+            "public_note": {
+              "type": "string"
+            },
+            "key_or_mode": {
+              "type": "string"
+            },
+            "system_code": {
+              "type": "string"
+            },
+            "musical_notation": {
+              "type": "string"
+            },
+            "voice_instrument": {
+              "type": "string"
+            },
+            "number_of_work": {
+              "type": "string"
+            },
+            "clef": {
+              "type": "string"
+            },
+            "text_incipit": {
+              "type": "string"
+            },
+            "coded_validity_note": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "key_signature": {
+              "type": "string"
+            },
+            "link_text": {
+              "type": "string"
+            },
+            "caption_or_heading": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string"
+            },
+            "general_note": {
+              "type": "string"
+            },
+            "number_of_excerpt": {
+              "type": "string"
+            },
+            "number_of_movement": {
+              "type": "string"
+            },
+            "time_signature": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "date_detection": true,
+      "numeric_detection": true
+    }
+  }
+}

--- a/invenio_marc21/mappings/marc21_authority.json
+++ b/invenio_marc21/mappings/marc21_authority.json
@@ -1,0 +1,4610 @@
+{
+  "mappings": {
+    "marc21_authority": {
+      "properties": {
+        "see_from_tracing_geographic_subdivision": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_numbering_peculiarities": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "numbering_peculiarities_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "content_type": {
+          "properties": {
+            "materials_specified": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "content_type_code": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "content_type_term": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_example_tracing_note": {
+          "properties": {
+            "explanatory_text": {
+              "type": "string"
+            },
+            "subject_heading_or_subdivision_term": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_form_subdivision": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "control_number": {
+          "type": "string"
+        },
+        "coded_cartographic_mathematical_data": {
+          "properties": {
+            "materials_specified": {
+              "type": "string"
+            },
+            "coordinates_northernmost_latitude": {
+              "type": "string"
+            },
+            "distance_from_earth": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "coordinates_easternmost_longitude": {
+              "type": "string"
+            },
+            "beginning_date": {
+              "type": "string"
+            },
+            "right_ascension_western_limit": {
+              "type": "string"
+            },
+            "right_ascension_eastern_limit": {
+              "type": "string"
+            },
+            "ending_date": {
+              "type": "string"
+            },
+            "declination_southern_limit": {
+              "type": "string"
+            },
+            "declination_northern_limit": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "coordinates_southernmost_latitude": {
+              "type": "string"
+            },
+            "name_of_extraterrestrial_body": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "type_of_ring": {
+              "type": "string"
+            },
+            "coordinates_westernmost_longitude": {
+              "type": "string"
+            },
+            "equinox": {
+              "type": "string"
+            },
+            "g_ring_latitude": {
+              "type": "string"
+            },
+            "g_ring_longitude": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "complex_see_also_reference_name": {
+          "properties": {
+            "explanatory_text": {
+              "type": "string"
+            },
+            "heading_referred_to": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "title_referred_to": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_corporate_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "type_of_corporate_name_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_meeting_or_treaty_signing": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "corporate_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "nonpublic_general_note": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "nonpublic_general_note": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "associated_language": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_code": {
+              "type": "string"
+            },
+            "language_code": {
+              "type": "string"
+            },
+            "language_term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subdivision_linking_entry_chronological_subdivision": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_geographic_subdivision": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "established_heading_linking_entry_corporate_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "type_of_corporate_name_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "date_of_meeting_or_treaty_signing": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "corporate_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subdivision_linking_entry_general_subdivision": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "associated_group": {
+          "properties": {
+            "associated_group": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "end_period": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "start_period": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "other_classification_number": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "explanatory_term": {
+              "type": "string"
+            },
+            "classification_number_element_ending_number_of_span": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "number_source": {
+              "type": "string"
+            },
+            "classification_number_element_single_number_or_beginning_of_span": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_uniform_title": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "control_number_identifier": {
+          "type": "string"
+        },
+        "see_also_from_tracing_general_subdivision": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_analysis_practice": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "series_analysis_practice": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_analysis_practice_applies": {
+              "type": "string"
+            },
+            "exceptions_to_analysis_practice": {
+              "type": "string"
+            },
+            "institution_copy_to_which_field_applies": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_geographic_name": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "geographic_name": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "established_heading_linking_entry_chronological_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "chronological_term": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "international_standard_serial_number": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "issn_l": {
+              "type": "string"
+            },
+            "canceled_issn_l": {
+              "type": "string"
+            },
+            "canceled_issn": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "incorrect_issn": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subject_category_code": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "code_source": {
+              "type": "string"
+            },
+            "subject_category_code_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "subject_category_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "universal_decimal_classification_number": {
+          "properties": {
+            "common_auxiliary_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "universal_decimal_classification_number": {
+              "type": "string"
+            },
+            "edition_identifier": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_genre_form_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "genre_form_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_personal_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "attribution_qualifier": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "dates_associated_with_a_name": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "fuller_form_of_name": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "numeration": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "type_of_personal_name_entry_element": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "personal_name": {
+              "type": "string"
+            },
+            "titles_and_other_words_associated_with_a_name": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "key": {
+          "properties": {
+            "key": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "special_coded_dates": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "ending_date_for_aggregated_content": {
+              "type": "string"
+            },
+            "end_period": {
+              "type": "string"
+            },
+            "source_of_date_scheme": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "termination_date": {
+              "type": "string"
+            },
+            "start_period": {
+              "type": "string"
+            },
+            "birth_date": {
+              "type": "string"
+            },
+            "single_or_starting_date_for_aggregated_content": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "death_date": {
+              "type": "string"
+            },
+            "ending_date_created": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "establishment_date": {
+              "type": "string"
+            },
+            "beginning_or_single_date_created": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "time_period_of_heading": {
+          "properties": {
+            "time_period_code": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "formatted_pre_9999_bc_time_period": {
+              "type": "string"
+            },
+            "formatted_9999_bc_through_ce_time_period": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "established_heading_linking_entry_genre_form_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "genre_form_term_as_entry_element": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_chronological_subdivision": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_meeting_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "type_of_meeting_name_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "meeting_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "name_of_meeting_following_jurisdiction_name_entry_element": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_meeting": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_general_subdivision": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "family_information": {
+          "properties": {
+            "name_of_prominent_member": {
+              "type": "string"
+            },
+            "hereditary_title": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "type_of_family": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "end_period": {
+              "type": "string"
+            },
+            "start_period": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "library_of_congress_call_number": {
+          "properties": {
+            "item_number": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_call_number_applies": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "geographic_area_code": {
+          "properties": {
+            "source_of_local_code": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "iso_code": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "geographic_area_code": {
+              "type": "string"
+            },
+            "local_gac_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_uniform_title": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_geographic_name": {
+          "properties": {
+            "geographic_name": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_medium_of_performance_term": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium_of_performance_term": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "history_reference": {
+          "properties": {
+            "history_reference": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "national_library_of_medicine_call_number": {
+          "properties": {
+            "item_number": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_call_number_applies": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_medium_of_performance_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "medium_of_performance_term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_chronological_term": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "chronological_term": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_geographic_name": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "geographic_name": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "other_standard_identifier": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_number_or_code": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "type_of_standard_number_or_code": {
+              "type": "string"
+            },
+            "additional_codes_following_the_standard_number_or_code": {
+              "type": "string"
+            },
+            "canceled_invalid_standard_number_or_code": {
+              "type": "string"
+            },
+            "standard_number_or_code": {
+              "type": "string"
+            },
+            "terms_of_availability": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "deleted_heading_information": {
+          "properties": {
+            "replacement_heading": {
+              "type": "string"
+            },
+            "explanatory_text": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "replacement_authority_record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "date_and_time_of_latest_transaction": {
+          "type": "string"
+        },
+        "see_also_from_tracing_corporate_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "type_of_corporate_name_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_meeting_or_treaty_signing": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "corporate_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "musical_incipits_information": {
+          "properties": {
+            "text_incipit": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "time_signature": {
+              "type": "string"
+            },
+            "link_text": {
+              "type": "string"
+            },
+            "role": {
+              "type": "string"
+            },
+            "number_of_movement": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "voice_instrument": {
+              "type": "string"
+            },
+            "musical_notation": {
+              "type": "string"
+            },
+            "general_note": {
+              "type": "string"
+            },
+            "public_note": {
+              "type": "string"
+            },
+            "key_signature": {
+              "type": "string"
+            },
+            "number_of_work": {
+              "type": "string"
+            },
+            "system_code": {
+              "type": "string"
+            },
+            "coded_validity_note": {
+              "type": "string"
+            },
+            "clef": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "number_of_excerpt": {
+              "type": "string"
+            },
+            "caption_or_heading": {
+              "type": "string"
+            },
+            "key_or_mode": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "other_distinguishing_characteristics_of_work_or_expression": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "other_distinguishing_characteristic": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "government_document_call_number": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "call_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "number_source": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_call_number_applies": {
+              "type": "string"
+            },
+            "canceled_invalid_call_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "international_standard_book_number": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "terms_of_availability": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "canceled_invalid_isbn": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "international_standard_book_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_topical_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "topical_term_following_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "topical_term_or_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "system_control_number": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "canceled_invalid_system_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "system_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "description_conversion_information": {
+          "properties": {
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "conversion_agency": {
+              "type": "string"
+            },
+            "identifier_of_source_metadata": {
+              "type": "string"
+            },
+            "conversion_date": {
+              "type": "string"
+            },
+            "conversion_process": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "application_history_note": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "application_history_note": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_uniform_title": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "nonfiling_characters": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "established_heading_linking_entry_geographic_name": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "geographic_name": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_form_subdivision": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subdivision_linking_entry_form_subdivision": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_general_subdivision": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_chronological_subdivision": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "complex_see_reference_subject": {
+          "properties": {
+            "explanatory_text": {
+              "type": "string"
+            },
+            "heading_referred_to": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "lc_classification_number": {
+          "properties": {
+            "classification_number_element_single_number_or_beginning_number_of_span": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "explanatory_term": {
+              "type": "string"
+            },
+            "classification_number_element_ending_number_of_span": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "occupation": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "occupation": {
+              "type": "string"
+            },
+            "end_period": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "start_period": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_form_subdivision": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "complex_see_reference_name": {
+          "properties": {
+            "explanatory_text": {
+              "type": "string"
+            },
+            "heading_referred_to": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "title_referred_to": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "national_bibliographic_agency_control_number": {
+          "properties": {
+            "record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "canceled_or_invalid_record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subdivision_linking_entry_geographic_subdivision": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "numeric_designation_of_musical_work": {
+          "properties": {
+            "thematic_index_code": {
+              "type": "string"
+            },
+            "publisher_associated_with_opus_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "serial_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "opus_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "thematic_index_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_topical_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "topical_term_following_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "topical_term_or_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "fixed_length_data_elements": {
+          "type": "string"
+        },
+        "series_dates_of_publication_and_or_sequential_designation": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "dates_of_publication_and_or_sequential_designation": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "address": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "electronic_mail_address": {
+              "type": "string"
+            },
+            "end_period": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "intermediate_jurisdiction": {
+              "type": "string"
+            },
+            "start_period": {
+              "type": "string"
+            },
+            "city": {
+              "type": "string"
+            },
+            "public_note": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "country": {
+              "type": "string"
+            },
+            "relator_code": {
+              "type": "string"
+            },
+            "postal_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_chronological_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "chronological_term": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "other_attributes_of_person_or_corporate_body": {
+          "properties": {
+            "type_of_corporate_body": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "end_period": {
+              "type": "string"
+            },
+            "type_of_jurisdiction": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "other_designation": {
+              "type": "string"
+            },
+            "start_period": {
+              "type": "string"
+            },
+            "title_of_person": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_personal_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "attribution_qualifier": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "dates_associated_with_a_name": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "fuller_form_of_name": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "numeration": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "type_of_personal_name_element": {
+              "type": "string"
+            },
+            "personal_name": {
+              "type": "string"
+            },
+            "titles_and_other_words_associated_with_a_name": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "authentication_code": {
+          "properties": {
+            "authentication_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "geographic_classification": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "code_source": {
+              "type": "string"
+            },
+            "populated_place_name": {
+              "type": "string"
+            },
+            "geographic_classification_area_code": {
+              "type": "string"
+            },
+            "geographic_classification_subarea_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_genre_form_term": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "genre_form_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "field_of_activity": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "field_of_activity": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "end_period": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "start_period": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "link_to_bibliographic_record_for_serial_or_multipart_item": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "control_number_of_related_bibliographic_record": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "established_heading_linking_entry_uniform_title": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "uniform_title": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "date_of_treaty_signing": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_geographic_subdivision": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "established_heading_linking_entry_meeting_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "type_of_meeting_name_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "meeting_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "name_of_meeting_following_jurisdiction_name_entry_element": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_meeting": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_genre_form_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "genre_form_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_chronological_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_term": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "established_heading_linking_entry_medium_of_performance_term": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "medium_of_performance_term_as_entry_element": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "machine_generated_metadata_provenance": {
+          "properties": {
+            "generation_agency": {
+              "type": "string"
+            },
+            "generation_date": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "generation_process": {
+              "type": "string"
+            },
+            "validity_end_date": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "bibliographic_record_control_number": {
+              "type": "string"
+            },
+            "confidence_value": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "method_of_machine_assignment": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "fuller_form_of_personal_name": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "fuller_form_of_personal_name": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_corporate_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "type_of_corporate_name_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_meeting_or_treaty_signing": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "corporate_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "established_heading_linking_entry_topical_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "topical_term_or_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "topical_term_following_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "complex_see_also_reference_subject": {
+          "properties": {
+            "explanatory_text": {
+              "type": "string"
+            },
+            "heading_referred_to": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "subdivision_usage": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "code_source": {
+              "type": "string"
+            },
+            "subdivision_usage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "government_document_classification_number": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "classification_number_element_ending_number_of_span": {
+              "type": "string"
+            },
+            "classification_number_element_single_number_of_beginning_number_of_span": {
+              "type": "string"
+            },
+            "number_source": {
+              "type": "string"
+            },
+            "explanatory_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_tracing_practice": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_tracing_practice_applies": {
+              "type": "string"
+            },
+            "series_tracing_practice": {
+              "type": "string"
+            },
+            "institution_copy_to_which_field_applies": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "complex_linking_entry_data": {
+          "properties": {
+            "explanatory_text": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "heading_referred_to": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "alternate_graphic_representation": {
+          "properties": {
+            "same_as_associated_field": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "general_explanatory_reference_name": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "general_explanatory_reference": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "form_of_work": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_of_work": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_medium_of_performance_term": {
+          "properties": {
+            "control_subfield": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium_of_performance_term": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "format_of_notated_music": {
+          "properties": {
+            "materials_specified": {
+              "type": "string"
+            },
+            "format_of_notated_music_term": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "format_of_notated_music_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "national_agricultural_library_call_number": {
+          "properties": {
+            "classification_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_call_number_applies": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "time_period_of_creation": {
+          "properties": {
+            "time_period_of_creation_term": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "type_of_time_period": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "dewey_decimal_call_number": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_call_number_applies": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "item_number": {
+              "type": "string"
+            },
+            "edition_number": {
+              "type": "string"
+            },
+            "type_of_edition": {
+              "type": "string"
+            },
+            "source_of_call_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_topical_term": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "topical_term_following_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "topical_term_or_geographic_name_entry_element": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "gender": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "end_period": {
+              "type": "string"
+            },
+            "gender": {
+              "type": "string"
+            },
+            "start_period": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "audience_characteristics": {
+          "properties": {
+            "audience_code": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "demographic_group_term": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "demographic_group_code": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "audience_term": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "cataloging_source": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "language_of_cataloging": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "modifying_agency": {
+              "type": "string"
+            },
+            "original_cataloging_agency": {
+              "type": "string"
+            },
+            "description_conventions": {
+              "type": "string"
+            },
+            "transcribing_agency": {
+              "type": "string"
+            },
+            "subject_heading_thesaurus_conventions": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_also_from_tracing_personal_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "attribution_qualifier": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "dates_associated_with_a_name": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "fuller_form_of_name": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "numeration": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "type_of_personal_name_entry_element": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "personal_name": {
+              "type": "string"
+            },
+            "titles_and_other_words_associated_with_a_name": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "established_heading_linking_entry_personal_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "attribution_qualifier": {
+              "type": "string"
+            },
+            "source_of_heading_or_term": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "dates_associated_with_a_name": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "number_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "fuller_form_of_name": {
+              "type": "string"
+            },
+            "thesaurus": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "numeration": {
+              "type": "string"
+            },
+            "arranged_statement_for_music": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "type_of_personal_name_entry_element": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "key_for_music": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "personal_name": {
+              "type": "string"
+            },
+            "titles_and_other_words_associated_with_a_name": {
+              "type": "string"
+            },
+            "medium_of_performance_for_music": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_classification_practice": {
+          "properties": {
+            "volumes_dates_to_which_classification_practice_applies": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "series_classification_practice": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "character_sets_present": {
+          "properties": {
+            "primary_g0_character_set": {
+              "type": "string"
+            },
+            "primary_g1_character_set": {
+              "type": "string"
+            },
+            "alternate_g0_or_g1_character_set": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "creator_contributor_characteristics": {
+          "properties": {
+            "materials_specified": {
+              "type": "string"
+            },
+            "creator_contributor_term": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "demographic_group_term": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "demographic_group_code": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "creator_contributor_code": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "public_general_note": {
+          "properties": {
+            "explanatory_text": {
+              "type": "string"
+            },
+            "heading_or_subdivision_term": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "see_from_tracing_meeting_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "type_of_meeting_name_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "control_subfield": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "name_of_meeting_following_jurisdiction_name_entry_element": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "date_of_meeting": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "relationship_code": {
+              "type": "string"
+            },
+            "meeting_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            },
+            "relationship_information": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "electronic_location_and_access": {
+          "properties": {
+            "name_of_location_of_host": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "settings": {
+              "type": "string"
+            },
+            "operating_system": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "terminal_emulation": {
+              "type": "string"
+            },
+            "access_method": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "public_note": {
+              "type": "string"
+            },
+            "instruction": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "logon": {
+              "type": "string"
+            },
+            "processor_of_request": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "string"
+            },
+            "host_name": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "electronic_format_type": {
+              "type": "string"
+            },
+            "link_text": {
+              "type": "string"
+            },
+            "hours_access_method_available": {
+              "type": "string"
+            },
+            "compression_information": {
+              "type": "string"
+            },
+            "bits_per_second": {
+              "type": "string"
+            },
+            "nonpublic_note": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "access_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "contact_for_access_assistance": {
+              "type": "string"
+            },
+            "electronic_name": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_numbering_example": {
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_series_numbering_example_applies": {
+              "type": "string"
+            },
+            "series_numbering_example": {
+              "type": "string"
+            },
+            "institution_copy_to_which_field_applies": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_meeting_name": {
+          "properties": {
+            "language_of_a_work": {
+              "type": "string"
+            },
+            "name_of_part_section_of_a_work": {
+              "type": "string"
+            },
+            "title_of_a_work": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "type_of_meeting_name_entry_element": {
+              "type": "string"
+            },
+            "relator_term": {
+              "type": "string"
+            },
+            "location_of_meeting": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "medium": {
+              "type": "string"
+            },
+            "name_of_meeting_following_jurisdiction_name_entry_element": {
+              "type": "string"
+            },
+            "date_of_a_work": {
+              "type": "string"
+            },
+            "miscellaneous_information": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "number_of_part_section_meeting": {
+              "type": "string"
+            },
+            "subordinate_unit": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "date_of_meeting": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subheading": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "meeting_name_or_jurisdiction_name_as_entry_element": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "series_place_and_publisher_issuing_body": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "place": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "publisher_issuing_body": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_place_and_publisher_issuing_body_apply": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "heading_chronological_subdivision": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "form_subdivision": {
+              "type": "string"
+            },
+            "chronological_subdivision": {
+              "type": "string"
+            },
+            "general_subdivision": {
+              "type": "string"
+            },
+            "geographic_subdivision": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "medium_of_performance": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "note": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "number_of_performers_of_the_same_medium": {
+              "type": "string"
+            },
+            "total_number_of_performers": {
+              "type": "string"
+            },
+            "number_of_ensembles": {
+              "type": "string"
+            },
+            "display_constant_controller": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "medium_of_performance": {
+              "type": "string"
+            },
+            "soloist": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "doubling_instrument": {
+              "type": "string"
+            },
+            "alternative_medium_of_performance": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "dewey_decimal_classification_number": {
+          "properties": {
+            "classification_number_element_single_number_or_beginning_number_of_span": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "explanatory_term": {
+              "type": "string"
+            },
+            "table_identification_table_number": {
+              "type": "string"
+            },
+            "classification_number_element_ending_number_of_span": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "source_of_classification_number": {
+              "type": "string"
+            },
+            "table_sequence_number_for_internal_subarrangement_or_add_table": {
+              "type": "string"
+            },
+            "edition_number": {
+              "type": "string"
+            },
+            "type_of_edition": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "library_and_archives_canada_call_number": {
+          "properties": {
+            "item_number": {
+              "type": "string"
+            },
+            "volumes_dates_to_which_call_number_applies": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "classification_number": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "associated_place": {
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "place_of_residence_headquarters": {
+              "type": "string"
+            },
+            "place_of_birth": {
+              "type": "string"
+            },
+            "end_period": {
+              "type": "string"
+            },
+            "other_associated_place": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "associated_country": {
+              "type": "string"
+            },
+            "start_period": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "place_of_death": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "source_of_information": {
+              "type": "string"
+            },
+            "place_of_origin_of_work": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "library_of_congress_control_number": {
+          "properties": {
+            "canceled_invalid_lc_control_number": {
+              "type": "string"
+            },
+            "lc_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "date_detection": true
+    }
+  }
+}

--- a/invenio_marc21/mappings/marc21_holdings.json
+++ b/invenio_marc21/mappings/marc21_holdings.json
@@ -1,0 +1,985 @@
+{
+  "mappings": {
+    "marc21_holdings": {
+      "properties": {
+        "library_of_congress_control_number": {
+          "type": "object",
+          "properties": {
+            "nucmc_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "lc_control_number": {
+              "type": "string"
+            },
+            "canceled_or_invalid_lc_control_number": {
+              "type": "string"
+            }
+          }
+        },
+        "coden_designation": {
+          "type": "object",
+          "properties": {
+            "canceled_invalid_coden": {
+              "type": "string"
+            },
+            "coden": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          }
+        },
+        "linkage_number": {
+          "type": "object",
+          "properties": {
+            "linkage_number": {
+              "type": "string"
+            },
+            "canceled_or_invalid_linkage_number": {
+              "type": "string"
+            },
+            "source_of_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          }
+        },
+        "captions_and_pattern_indexes": {
+          "type": "object",
+          "properties": {}
+        },
+        "ownership_and_custodial_history": {
+          "type": "object",
+          "properties": {
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "privacy": {
+              "type": "string"
+            },
+            "history": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          }
+        },
+        "record_source": {
+          "type": "object",
+          "properties": {
+            "original_cataloging_agency": {
+              "type": "string"
+            },
+            "modifying_agency": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "language_of_cataloging": {
+              "type": "string"
+            },
+            "transcribing_agency": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          }
+        },
+        "textual_physical_form_designator": {
+          "type": "object",
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "textual_physical_form_designator": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          }
+        },
+        "control_number": {
+          "type": "string"
+        },
+        "description_conversion_information": {
+          "type": "object",
+          "properties": {
+            "identifier_of_source_metadata": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "conversion_process": {
+              "type": "string"
+            },
+            "conversion_agency": {
+              "type": "string"
+            },
+            "conversion_date": {
+              "type": "string"
+            }
+          }
+        },
+        "item_information_supplementary_material": {
+          "type": "object",
+          "properties": {}
+        },
+        "system_details_note": {
+          "type": "object",
+          "properties": {
+            "system_details_note": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "display_text": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          }
+        },
+        "control_number_identifier": {
+          "type": "string"
+        },
+        "captions_and_pattern_supplementary_material": {
+          "type": "object",
+          "properties": {}
+        },
+        "textual_holdings_basic_bibliographic_unit": {
+          "type": "object",
+          "properties": {}
+        },
+        "carrier_type": {
+          "type": "object",
+          "properties": {
+            "carrier_type_term": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "carrier_type_code": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          }
+        },
+        "alternate_graphic_representation": {
+          "type": "object",
+          "properties": {
+            "same_as_associated_field": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            }
+          }
+        },
+        "item_information_indexes": {
+          "type": "object",
+          "properties": {}
+        },
+        "enumeration_and_chronology_basic_bibliographic_unit": {
+          "type": "object",
+          "properties": {}
+        },
+        "standard_technical_report_number": {
+          "type": "object",
+          "properties": {
+            "standard_technical_report_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "canceled_invalid_strn": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            }
+          }
+        },
+        "captions_and_pattern_basic_bibliographic_unit": {
+          "type": "object",
+          "properties": {}
+        },
+        "restrictions_on_access_note": {
+          "type": "object",
+          "properties": {
+            "authorization": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "terms_governing_access": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "standardized_terminology_for_access_restriction": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "authorized_users": {
+              "type": "string"
+            },
+            "jurisdiction": {
+              "type": "string"
+            },
+            "physical_access_provisions": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            }
+          }
+        },
+        "media_type": {
+          "type": "object",
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "media_type_code": {
+              "type": "string"
+            },
+            "media_type_term": {
+              "type": "string"
+            }
+          }
+        },
+        "other_standard_identifier": {
+          "type": "object",
+          "properties": {
+            "additional_codes_following_the_standard_number_or_code": {
+              "type": "string"
+            },
+            "type_of_standard_number_or_code": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "source_of_number_or_code": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "standard_number_or_code": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "difference_indicator": {
+              "type": "string"
+            },
+            "canceled_invalid_standard_number_or_code": {
+              "type": "string"
+            },
+            "terms_of_availability": {
+              "type": "string"
+            }
+          }
+        },
+        "character_sets_present": {
+          "type": "object",
+          "properties": {
+            "alternate_g0_or_g1_character_set": {
+              "type": "string"
+            },
+            "primary_g0_character_set": {
+              "type": "string"
+            },
+            "primary_g1_character_set": {
+              "type": "string"
+            }
+          }
+        },
+        "item_information_basic_bibliographic_unit": {
+          "type": "object",
+          "properties": {}
+        },
+        "enumeration_and_chronology_indexes": {
+          "type": "object",
+          "properties": {}
+        },
+        "textual_holdings_supplementary_material": {
+          "type": "object",
+          "properties": {}
+        },
+        "system_control_number": {
+          "type": "object",
+          "properties": {
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "system_control_number": {
+              "type": "string"
+            },
+            "canceled_or_invalid_control_number": {
+              "type": "string"
+            }
+          }
+        },
+        "name_of_unit": {
+          "type": "object",
+          "properties": {
+            "name_of_unit": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          }
+        },
+        "holdings_coded_data_values": {
+          "type": "object",
+          "properties": {
+            "type_of_record": {
+              "type": "string"
+            },
+            "encoding_level": {
+              "type": "string"
+            },
+            "fixed_length_data_elements": {
+              "type": "string"
+            }
+          }
+        },
+        "copy_and_version_identification_note": {
+          "type": "object",
+          "properties": {
+            "presentation_format": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "number_of_copies": {
+              "type": "string"
+            },
+            "copy_identification": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "version_identification": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "identifying_markings": {
+              "type": "string"
+            }
+          }
+        },
+        "national_bibliographic_agency_control_number": {
+          "type": "object",
+          "properties": {
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "canceled_or_invalid_control_number": {
+              "type": "string"
+            }
+          }
+        },
+        "enumeration_and_chronology_supplementary_material": {
+          "type": "object",
+          "properties": {}
+        },
+        "reproduction_note": {
+          "type": "object",
+          "properties": {
+            "fixed_length_data_elements_of_reproduction": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "note_about_reproduction": {
+              "type": "string"
+            },
+            "place_of_reproduction": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "dates_of_publication_and_or_sequential_designation_of_issues_reproduced": {
+              "type": "string"
+            },
+            "series_statement_of_reproduction": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "date_of_reproduction": {
+              "type": "string"
+            },
+            "type_of_reproduction": {
+              "type": "string"
+            },
+            "agency_responsible_for_reproduction": {
+              "type": "string"
+            },
+            "physical_description_of_reproduction": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            }
+          }
+        },
+        "international_standard_book_number": {
+          "type": "object",
+          "properties": {
+            "international_standard_book_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "terms_of_availability": {
+              "type": "string"
+            },
+            "qualifying_information": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "canceled_invalid_isbn": {
+              "type": "string"
+            }
+          }
+        },
+        "machine_generated_metadata_provenance": {
+          "type": "object",
+          "properties": {
+            "method_of_machine_assignment": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "confidence_value": {
+              "type": "string"
+            },
+            "generation_agency": {
+              "type": "string"
+            },
+            "generation_date": {
+              "type": "string"
+            },
+            "authority_record_control_number_or_standard_number": {
+              "type": "string"
+            },
+            "validity_end_date": {
+              "type": "string"
+            },
+            "bibliographic_record_control_number": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "generation_process": {
+              "type": "string"
+            }
+          }
+        },
+        "location": {
+          "type": "object",
+          "properties": {
+            "source_of_classification_or_shelving_scheme": {
+              "type": "string"
+            },
+            "shelving_control_number": {
+              "type": "string"
+            },
+            "call_number_prefix": {
+              "type": "string"
+            },
+            "classification_part": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "public_note": {
+              "type": "string"
+            },
+            "nonpublic_note": {
+              "type": "string"
+            },
+            "copy_number": {
+              "type": "string"
+            },
+            "sequence_number": {
+              "type": "string"
+            },
+            "former_shelving_location": {
+              "type": "string"
+            },
+            "call_number_suffix": {
+              "type": "string"
+            },
+            "sublocation_or_collection": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "shelving_form_of_title": {
+              "type": "string"
+            },
+            "shelving_location": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "non_coded_location_qualifier": {
+              "type": "string"
+            },
+            "item_part": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "piece_physical_condition": {
+              "type": "string"
+            },
+            "copyright_article_fee_code": {
+              "type": "string"
+            },
+            "location": {
+              "type": "string"
+            },
+            "country_code": {
+              "type": "string"
+            },
+            "piece_designation": {
+              "type": "string"
+            },
+            "coded_location_qualifier_\n": {
+              "type": "string"
+            }
+          }
+        },
+        "date_and_time_of_latest_transaction": {
+          "type": "string"
+        },
+        "immediate_source_of_acquisition_note": {
+          "type": "object",
+          "properties": {
+            "materials_specified": {
+              "type": "string"
+            },
+            "source_of_acquisition": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "owner": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "method_of_acquisition": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "extent": {
+              "type": "string"
+            },
+            "accession_number": {
+              "type": "string"
+            },
+            "purchase_price": {
+              "type": "string"
+            },
+            "type_of_unit": {
+              "type": "string"
+            },
+            "date_of_acquisition": {
+              "type": "string"
+            }
+          }
+        },
+        "action_note": {
+          "type": "object",
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "site_of_action": {
+              "type": "string"
+            },
+            "authorization": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "action_agent": {
+              "type": "string"
+            },
+            "method_of_action": {
+              "type": "string"
+            },
+            "jurisdiction": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            },
+            "action_interval": {
+              "type": "string"
+            },
+            "action_identification": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "extent": {
+              "type": "string"
+            },
+            "public_note": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "nonpublic_note": {
+              "type": "string"
+            },
+            "source_of_term": {
+              "type": "string"
+            },
+            "contingency_for_action": {
+              "type": "string"
+            },
+            "type_of_unit": {
+              "type": "string"
+            },
+            "time_date_of_action": {
+              "type": "string"
+            }
+          }
+        },
+        "international_standard_serial_number": {
+          "type": "object",
+          "properties": {
+            "canceled_issn_l": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "international_standard_serial_number": {
+              "type": "string"
+            },
+            "canceled_issn": {
+              "type": "string"
+            },
+            "incorrect_issn": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "issn_l": {
+              "type": "string"
+            }
+          }
+        },
+        "electronic_location_and_access": {
+          "type": "object",
+          "properties": {
+            "contact_for_access_assistance": {
+              "type": "string"
+            },
+            "access_number": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            },
+            "operating_system": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "public_note": {
+              "type": "string"
+            },
+            "host_name": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "port": {
+              "type": "string"
+            },
+            "terminal_emulation": {
+              "type": "string"
+            },
+            "nonpublic_note": {
+              "type": "string"
+            },
+            "file_size": {
+              "type": "string"
+            },
+            "record_control_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "bits_per_second": {
+              "type": "string"
+            },
+            "processor_of_request": {
+              "type": "string"
+            },
+            "access_method": {
+              "type": "string"
+            },
+            "logon": {
+              "type": "string"
+            },
+            "instruction": {
+              "type": "string"
+            },
+            "name_of_location_of_host": {
+              "type": "string"
+            },
+            "electronic_name": {
+              "type": "string"
+            },
+            "password": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "electronic_format_type": {
+              "type": "string"
+            },
+            "hours_access_method_available": {
+              "type": "string"
+            },
+            "compression_information": {
+              "type": "string"
+            },
+            "settings": {
+              "type": "string"
+            },
+            "link_text": {
+              "type": "string"
+            }
+          }
+        },
+        "textual_holdings_indexes": {
+          "type": "object",
+          "properties": {}
+        },
+        "copyright_or_legal_deposit_number": {
+          "type": "object",
+          "properties": {
+            "date": {
+              "type": "string"
+            },
+            "assigning_agency": {
+              "type": "string"
+            },
+            "copyright_or_legal_deposit_number": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "source": {
+              "type": "string"
+            },
+            "display_text": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "canceled_invalid_copyright_or_legal_deposit_number": {
+              "type": "string"
+            }
+          }
+        },
+        "binding_information": {
+          "type": "object",
+          "properties": {
+            "binding_note": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          }
+        },
+        "terms_governing_use_and_reproduction_note": {
+          "type": "object",
+          "properties": {
+            "uniform_resource_identifier": {
+              "type": "string"
+            },
+            "authorization": {
+              "type": "string"
+            },
+            "terms_governing_use_and_reproduction": {
+              "type": "string"
+            },
+            "materials_specified": {
+              "type": "string"
+            },
+            "authorized_users": {
+              "type": "string"
+            },
+            "jurisdiction": {
+              "type": "string"
+            },
+            "linkage": {
+              "type": "string"
+            },
+            "field_link_and_sequence_number": {
+              "type": "string"
+            },
+            "institution_to_which_field_applies": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,11 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
+    'dojson>=1.0.1',
+    'invenio-db>=1.0.0a9',
+    'invenio-indexer>=1.0.0a1',
+    'invenio-records>=1.0.0a9',
+    'invenio-search>=1.0.0a4',
 ]
 
 extras_require = {
@@ -94,17 +99,9 @@ setup(
         'invenio_i18n.translations': [
             'messages = invenio_marc21',
         ],
-        # TODO: Edit these entry points to fit your needs.
-        # 'invenio_access.actions': [],
-        # 'invenio_admin.actions': [],
-        # 'invenio_assets.bundles': [],
-        # 'invenio_base.api_apps': [],
-        # 'invenio_base.api_blueprints': [],
-        # 'invenio_base.blueprints': [],
-        # 'invenio_celery.tasks': [],
-        # 'invenio_db.models': [],
-        # 'invenio_pidstore.minters': [],
-        # 'invenio_records.jsonresolver': [],
+        'invenio_search.mappings': [
+            'mappings = invenio_marc21',
+        ]
     },
     extras_require=extras_require,
     install_requires=install_requires,

--- a/tests/test_invenio_marc21.py
+++ b/tests/test_invenio_marc21.py
@@ -27,8 +27,13 @@
 
 from __future__ import absolute_import, print_function
 
+import pkg_resources
+from dojson.contrib.marc21.utils import load
 from flask import Flask
 from flask_babelex import Babel
+from invenio_indexer.api import RecordIndexer
+from invenio_records import Record
+from invenio_search import InvenioSearch
 
 from invenio_marc21 import InvenioMARC21
 
@@ -60,3 +65,49 @@ def test_view(app):
         res = client.get("/")
         assert res.status_code == 200
         assert 'Welcome to Invenio-MARC21' in str(res.data)
+
+
+def test_authority_data(es_app):
+    """Test indexation using authority data."""
+    search = InvenioSearch(es_app)
+    search.create()
+    indexer = RecordIndexer()
+    with es_app.test_request_context():
+        data_filename = pkg_resources.resource_filename(
+            'invenio_records', 'data/marc21/authority.xml')
+        records_data = load(data_filename)
+        records = []
+        for item in records_data:
+            record = Record.create(item)
+            record['$schema'] = "mappings/marc21_authority.json"
+            es_record = indexer.index(record)
+            records.append(es_record)
+
+    for record in records:
+        search.client.get(index=record['_index'],
+                          doc_type=record['_type'],
+                          id=record['_id'])
+    search.delete()
+
+
+def test_bibliographic_data(es_app):
+    """Test indexation using bibliographic data."""
+    search = InvenioSearch(es_app)
+    search.create()
+    indexer = RecordIndexer()
+    with es_app.test_request_context():
+        data_filename = pkg_resources.resource_filename(
+            'invenio_records', 'data/marc21/bibliographic.xml')
+        records_data = load(data_filename)
+        records = []
+        for item in records_data:
+            record = Record.create(item)
+            record['$schema'] = "mappings/marc21_holdings.json"
+            es_record = indexer.index(record)
+            records.append(es_record)
+
+    for record in records:
+        search.client.get(index=record['_index'],
+                          doc_type=record['_type'],
+                          id=record['_id'])
+    search.delete()


### PR DESCRIPTION
* Adds MARC21 mappings (Including Authority and Holdings). (closes #5)

* Adds a test to check that example data is indexed according to the mapping.

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>